### PR TITLE
Hide locked cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,11 @@
                                     <option value="rising">Rising Prices</option>
                                     <option value="falling">Falling Prices</option>
                                 </select>
+                                <button id="hide-locked-toggle" class="text-sm rounded-lg px-3 py-2 transition-colors font-medium" 
+                                        style="background-color: var(--bg-tertiary); border: 1px solid var(--border-primary); color: var(--text-primary); width: 120px;" 
+                                        title="Hide cards that are completely locked and cannot be sold">
+                                    Hide Locked
+                                </button>
                                 <button id="sell-all-btn"
                             class="bg-red-600 hover:bg-red-700 text-white font-bold px-6 py-3 rounded-lg text-lg transition-colors"
                             style="background-color: #dc2626 !important; box-shadow: 0 4px 8px rgba(220, 38, 38, 0.3);">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcg-pack-simulator",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A Trading Card Game Pack Opening Simulator built with Electron",
   "main": "main.js",
   "scripts": {

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -47,6 +47,7 @@ class UIManager {
         this.portfolioSearch = document.getElementById('portfolio-search');
         this.portfolioSort = document.getElementById('portfolio-sort');
         this.portfolioFilter = document.getElementById('portfolio-filter');
+        this.hideLockedToggle = document.getElementById('hide-locked-toggle');
         this.marketSummary = document.getElementById('market-summary');
         this.hotCardsList = document.getElementById('hot-cards-list');
         
@@ -164,7 +165,8 @@ class UIManager {
         this.portfolioFilters = {
             search: '',
             sort: 'value-desc',
-            filter: 'all'
+            filter: 'all',
+            hideLockedCards: false
         };
         this.collectionFilters = {
             search: '',
@@ -669,6 +671,13 @@ class UIManager {
         
         this.portfolioFilter.addEventListener('change', (e) => {
             this.portfolioFilters.filter = e.target.value;
+            this.renderPortfolio();
+        });
+
+        // Hide locked cards toggle
+        this.hideLockedToggle.addEventListener('click', (e) => {
+            this.portfolioFilters.hideLockedCards = !this.portfolioFilters.hideLockedCards;
+            this.updateHideLockedToggleAppearance();
             this.renderPortfolio();
         });
 
@@ -1396,7 +1405,26 @@ class UIManager {
         }
     }
 
+    updateHideLockedToggleAppearance() {
+        if (this.portfolioFilters.hideLockedCards) {
+            this.hideLockedToggle.style.backgroundColor = '#10b981'; // Green when active
+            this.hideLockedToggle.style.borderColor = '#10b981';
+            this.hideLockedToggle.style.color = 'white';
+            this.hideLockedToggle.textContent = 'Show All';
+            this.hideLockedToggle.title = 'Currently hiding locked cards. Click to show all cards.';
+        } else {
+            this.hideLockedToggle.style.backgroundColor = 'var(--bg-tertiary)';
+            this.hideLockedToggle.style.borderColor = 'var(--border-primary)';
+            this.hideLockedToggle.style.color = 'var(--text-primary)';
+            this.hideLockedToggle.textContent = 'Hide Locked';
+            this.hideLockedToggle.title = 'Hide cards that are completely locked and cannot be sold';
+        }
+    }
+
     renderPortfolio() {
+        // Update toggle appearance
+        this.updateHideLockedToggleAppearance();
+        
         const portfolio = this.gameEngine.getPortfolioSummary();
         
         //this.portfolioValue.textContent = portfolio.totalValue.toFixed(2);
@@ -1506,6 +1534,13 @@ class UIManager {
                 }
             }
             
+            // Hide locked cards filter
+            if (this.portfolioFilters.hideLockedCards) {
+                const availableRegular = this.gameEngine.getAvailableQuantityForSale(card.setId, card.cardName, false);
+                const availableFoil = this.gameEngine.getAvailableQuantityForSale(card.setId, card.cardName, true);
+                if (availableRegular === 0 && availableFoil === 0) return false;
+            }
+
             // Rarity filter
             if (this.portfolioFilters.filter !== 'all') {
                 switch (this.portfolioFilters.filter) {


### PR DESCRIPTION
Add a toggle on Portfolio to hide locked cards.

It only hides totally locked out cards, so 1x of each foil, all rares, all myths, etc. If your lock is set to 1 of each and you have 2x, that card will appear in Portfolio.