### PR TITLE
Optimize screenshot queue deduplication and cache management

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -54,7 +54,9 @@ class TCGPackSimulator {
             if (originalMethod) {
                 this.uiManager.switchTab = (tabName) => {
                     if (tabName !== 'collection') {
-                        window.glyphArtGenerator.clearPerformanceCache();
+                        // Trim excess entries rather than wiping the cache entirely,
+                        // so screenshots remain available when the user returns to the collection tab.
+                        window.glyphArtGenerator.manageCacheSize(50);
                     }
                     return originalMethod.call(this.uiManager, tabName);
                 };
@@ -67,8 +69,8 @@ class TCGPackSimulator {
             
             // Conservative memory management - clean every 2 minutes
             setInterval(() => {
-                if (window.glyphArtGenerator.getCacheStats().imageCache > 30) {
-                    window.glyphArtGenerator.manageCacheSize(30);
+                if (window.glyphArtGenerator.getCacheStats().imageCache > 50) {
+                    window.glyphArtGenerator.manageCacheSize(50);
                 }
             }, 120000); // 2 minutes
         }

--- a/src/js/glyphArt.js
+++ b/src/js/glyphArt.js
@@ -289,7 +289,7 @@ class GlyphArtGenerator {
     
     // Performance optimization: Image cache for collection views
     imageCache = new Map();
-    screenshotQueue = new Set();
+    screenshotQueue = new Map(); // keyed by cacheKey for deduplication
     isProcessingScreenshots = false;
     
     // Smart screenshot generation - only for collection views with many cards
@@ -310,8 +310,8 @@ class GlyphArtGenerator {
             `;
         }
         
-        // Add to queue for batch processing (don't await)
-        this.screenshotQueue.add({ cardName, rarity, width, height, cacheKey });
+        // Add to queue for batch processing; Map keyed on cacheKey deduplicates automatically
+        this.screenshotQueue.set(cacheKey, { cardName, rarity, width, height, cacheKey });
         
         // Start processing if not already running (don't await)
         if (!this.isProcessingScreenshots) {
@@ -334,10 +334,10 @@ class GlyphArtGenerator {
         try {
             // Process only 3 screenshots at a time to avoid blocking
             const batchSize = 3;
-            const batch = Array.from(this.screenshotQueue).slice(0, batchSize);
-            
+            const batch = Array.from(this.screenshotQueue.values()).slice(0, batchSize);
+
             for (const item of batch) {
-                this.screenshotQueue.delete(item);
+                this.screenshotQueue.delete(item.cacheKey);
                 
                 try {
                     const imageData = await this.createScreenshot(item.cardName, item.rarity, item.width, item.height);

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1368,11 +1368,6 @@ class UIManager {
             if (enableSmartOptimization) {
                 // Use smart screenshot optimization for collection views
                 artHTML = window.glyphArtGenerator.generateScreenshotWhenNeeded(name, rarity, 300, 200);
-                if (typeof artHTML === 'object' && artHTML.then) {
-                    // Handle promise - use DOM version while screenshot processes
-                    const artData = window.glyphArtGenerator.generateArt(name, rarity);
-                    artHTML = window.glyphArtGenerator.renderArtHTML(artData);
-                }
             } else {
                 // Use regular DOM rendering for pack opening and single cards
                 const artData = window.glyphArtGenerator.generateArt(name, rarity);


### PR DESCRIPTION
## Summary
This PR improves performance and memory management for the glyph art generator by implementing smarter screenshot queue deduplication and adjusting cache retention policies.

## Key Changes

- **Screenshot Queue Deduplication**: Changed `screenshotQueue` from a `Set` to a `Map` keyed by `cacheKey`. This automatically deduplicates requests for the same card, preventing redundant screenshot generation when the same card is rendered multiple times.

- **Cache Retention Strategy**: Modified cache management to trim excess entries rather than completely clearing the cache when navigating away from the collection tab. This preserves generated screenshots so they remain available when users return to the collection view, improving perceived performance.

- **Cache Size Thresholds**: Increased the cache size threshold from 30 to 50 entries before triggering cleanup, allowing more screenshots to be retained in memory while still maintaining reasonable memory usage.

- **Simplified Promise Handling**: Removed unnecessary promise handling logic in `ui.js` that was attempting to handle async screenshot generation, since the queue-based approach now handles this more elegantly.

## Implementation Details

- The `screenshotQueue.set(cacheKey, {...})` call automatically replaces any existing entry with the same key, eliminating duplicate work
- Batch processing now correctly deletes items using `item.cacheKey` instead of the entire item object
- The 2-minute cache cleanup interval now uses the higher threshold (50 entries) to be more conservative with memory
- Tab switching now calls `manageCacheSize(50)` instead of `clearPerformanceCache()` to preserve cached screenshots

https://claude.ai/code/session_01R8AoNeMMx13QS4PCn8UBvA